### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: ruby
 rvm:
-  - 2.0.0
-  - 2.1.5
+  - 2.1
+  - 2.2
+  - 2.3.5
+  - 2.4.2
+before_install:
+  - gem install bundler -v 1.15.3
 script:
   - bundle install
   - bundle exec rake

--- a/fluent-plugin-filter-object-flatten.gemspec
+++ b/fluent-plugin-filter-object-flatten.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '>= 3.0.0'
+  spec.add_development_dependency 'test-unit', '>= 3.2.0'
 end

--- a/fluent-plugin-filter-object-flatten.gemspec
+++ b/fluent-plugin-filter-object-flatten.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'fluentd', '>= 0.12'
+  spec.add_dependency 'fluentd', ['>= 0.14.0', '< 2']
   spec.add_dependency 'object_flatten', '>= 0.1.1'
 
   spec.add_development_dependency 'bundler'

--- a/lib/fluent/plugin/filter_object_flatten.rb
+++ b/lib/fluent/plugin/filter_object_flatten.rb
@@ -1,9 +1,10 @@
 require 'fluent_plugin_filter_object_flatten/version'
 require 'object_flatten'
+require 'fluent/plugin/filter'
 
-module Fluent
+module Fluent::Plugin
   class ObjectFlattenFilter < Filter
-    Plugin.register_filter('object_flatten', self)
+    Fluent::Plugin.register_filter('object_flatten', self)
 
     config_param :separator, :string, :default => '.'
     config_param :tr,        :array,  :default => nil
@@ -14,7 +15,7 @@ module Fluent
 
       if @tr
         if @tr.length != 2
-          raise ConfigError, "tr: wrong length (#{@tr.length} for 2)"
+          raise Fluent::ConfigError, "tr: wrong length (#{@tr.length} for 2)"
         end
 
         @flatten_option[:tr] = @tr

--- a/spec/filter_object_flatten_config_spec.rb
+++ b/spec/filter_object_flatten_config_spec.rb
@@ -1,4 +1,4 @@
-describe 'Fluent::ObjectFlattenFilter#configure' do
+describe 'Fluent::Plugin::ObjectFlattenFilter#configure' do
   subject do |example|
     param = example.full_description.split(/\s+/)[1]
     create_driver(fluentd_conf).instance.send(param)

--- a/spec/filter_object_flatten_spec.rb
+++ b/spec/filter_object_flatten_spec.rb
@@ -1,15 +1,18 @@
-describe Fluent::ObjectFlattenFilter do
+describe Fluent::Plugin::ObjectFlattenFilter do
+  include Fluent::Test::Helpers
+
   let(:driver) { create_driver(fluentd_conf) }
   let(:fluentd_conf) { {} }
-  let(:time) { Time.parse('2015/05/24 18:30 UTC').to_i }
+  let(:time) { event_time('2015/05/24 18:30 UTC') }
   let(:obj) { described_class }
 
   before do
-    driver.emit(obj, time)
-    driver.run
+    driver.run(default_tag: 'test.default') do
+      driver.feed(time, obj)
+    end
   end
 
-  subject { driver.emits }
+  subject { driver.filtered }
 
   context({}) do
     it { is_expected.to be_empty }
@@ -18,7 +21,7 @@ describe Fluent::ObjectFlattenFilter do
   context("foo"=>"bar") do
     it do
       is_expected.to eq [
-        ["test.default", time, {"foo"=>"bar"}]
+        [time, {"foo"=>"bar"}]
       ]
     end
   end
@@ -26,8 +29,8 @@ describe Fluent::ObjectFlattenFilter do
   context("foo"=>"bar", "bar"=>"zoo") do
     it do
       is_expected.to eq [
-        ["test.default", time, {"foo"=>"bar"}],
-        ["test.default", time, {"bar"=>"zoo"}]
+        [time, {"foo"=>"bar"}],
+        [time, {"bar"=>"zoo"}]
       ]
     end
   end
@@ -35,8 +38,8 @@ describe Fluent::ObjectFlattenFilter do
   context("foo"=>["bar", "zoo"]) do
     it do
       is_expected.to eq [
-        ["test.default", time, {"foo"=>"bar"}],
-        ["test.default", time, {"foo"=>"zoo"}]
+        [time, {"foo"=>"bar"}],
+        [time, {"foo"=>"zoo"}]
       ]
     end
   end
@@ -44,8 +47,8 @@ describe Fluent::ObjectFlattenFilter do
   context("foo"=>{"bar1"=>"zoo", "bar2"=>"baz"}) do
     it do
       is_expected.to eq [
-        ["test.default", time, {"foo.bar1"=>"zoo"}],
-        ["test.default", time, {"foo.bar2"=>"baz"}]
+        [time, {"foo.bar1"=>"zoo"}],
+        [time, {"foo.bar2"=>"baz"}]
       ]
     end
   end
@@ -55,8 +58,8 @@ describe Fluent::ObjectFlattenFilter do
 
     it do
       is_expected.to eq [
-        ["test.default", time, {"foo/bar1"=>"zoo"}],
-        ["test.default", time, {"foo/bar2"=>"baz"}]
+        [time, {"foo/bar1"=>"zoo"}],
+        [time, {"foo/bar2"=>"baz"}]
       ]
     end
   end
@@ -65,11 +68,11 @@ describe Fluent::ObjectFlattenFilter do
           "foo2"=>{"bar"=>["zoo","baz"], "zoo"=>"baz"}) do
     it do
       is_expected.to eq [
-        ["test.default", time, {"foo1.bar1"=>"zoo"}],
-        ["test.default", time, {"foo1.bar2"=>"baz"}],
-        ["test.default", time, {"foo2.bar"=>"zoo"}],
-        ["test.default", time, {"foo2.bar"=>"baz"}],
-        ["test.default", time, {"foo2.zoo"=>"baz"}]
+        [time, {"foo1.bar1"=>"zoo"}],
+        [time, {"foo1.bar2"=>"baz"}],
+        [time, {"foo2.bar"=>"zoo"}],
+        [time, {"foo2.bar"=>"baz"}],
+        [time, {"foo2.zoo"=>"baz"}]
       ]
     end
   end
@@ -78,10 +81,10 @@ describe Fluent::ObjectFlattenFilter do
           "foo2"=>{"bar"=>{"zoo"=>["baz1","baz2"]}}) do
     it do
       is_expected.to eq [
-        ["test.default", time, {"foo1.bar.zoo1"=>"baz"}],
-        ["test.default", time, {"foo1.bar.zoo2"=>"baz"}],
-        ["test.default", time, {"foo2.bar.zoo"=>"baz1"}],
-        ["test.default", time, {"foo2.bar.zoo"=>"baz2"}]
+        [time, {"foo1.bar.zoo1"=>"baz"}],
+        [time, {"foo1.bar.zoo2"=>"baz"}],
+        [time, {"foo2.bar.zoo"=>"baz1"}],
+        [time, {"foo2.bar.zoo"=>"baz2"}]
       ]
     end
   end
@@ -92,11 +95,11 @@ describe Fluent::ObjectFlattenFilter do
 
     it do
       is_expected.to eq [
-        ["test.default", time, {"f_oo1.b_ar1"=>"zoo"}],
-        ["test.default", time, {"f_oo1.b_ar2"=>"baz"}],
-        ["test.default", time, {"f_oo2.b_ar"=>"zoo"}],
-        ["test.default", time, {"f_oo2.b_ar"=>"baz"}],
-        ["test.default", time, {"f_oo2.z_oo"=>"baz"}]
+        [time, {"f_oo1.b_ar1"=>"zoo"}],
+        [time, {"f_oo1.b_ar2"=>"baz"}],
+        [time, {"f_oo2.b_ar"=>"zoo"}],
+        [time, {"f_oo2.b_ar"=>"baz"}],
+        [time, {"f_oo2.z_oo"=>"baz"}]
       ]
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,3 +33,6 @@ tr #{options[:tr].inspect}
   tag = options[:tag] || 'test.default'
   Fluent::Test::FilterTestDriver.new(Fluent::ObjectFlattenFilter, tag).configure(fluentd_conf)
 end
+
+# prevent Test::Unit's AutoRunner from executing during RSpec's rake task
+Test::Unit.run = true if defined?(Test::Unit) && Test::Unit.respond_to?(:run=)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 require 'fluent/test'
+require 'fluent/test/helpers'
+require 'fluent/test/driver/filter'
 require 'fluent/plugin/filter_object_flatten'
 require 'time'
 
@@ -30,8 +32,7 @@ tr #{options[:tr].inspect}
     EOS
   end
 
-  tag = options[:tag] || 'test.default'
-  Fluent::Test::FilterTestDriver.new(Fluent::ObjectFlattenFilter, tag).configure(fluentd_conf)
+  Fluent::Test::Driver::Filter.new(Fluent::Plugin::ObjectFlattenFilter).configure(fluentd_conf)
 end
 
 # prevent Test::Unit's AutoRunner from executing during RSpec's rake task


### PR DESCRIPTION
I've tried to migrate to use v0.14 Filter Plugin API.
Using v0.14 API permits to handle nanosecond precision time in event.
This PR contains major update change and also includes in breaking changes.
If above questions/problems are acceptable or reasonable for you, could you bump up major version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks.